### PR TITLE
Add new `components` components to the registry

### DIFF
--- a/app/github-stats/page.tsx
+++ b/app/github-stats/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from "next";
+import OpenV0 from "@/components/open-v0";
+import { Separator } from "@/components/ui/separator";
+
+import CopyShadcn from "@/components/copy-shadcn";
+import CopyURL from "@/components/copy-url";
+import {
+  GithubForksExample,
+  GithubIssuesExample,
+  GithubPRExample,
+  GithubStarsExample,
+} from "@/components/examples/github-stats";
+import OpenCode from "@/components/open-code";
+
+export const metadata: Metadata = {
+  title: "Github Stats Components",
+  description:
+    "A collection of Github Stats components. Using React, TypeScript, and Tailwind CSS. Install the components using the shadcn/cli or open it in v0.",
+  openGraph: {
+    url: "/github-stats",
+    siteName: "Github Stats Components",
+    images: [
+      {
+        url: "/github-stats/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Github Stats Components",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+};
+
+const components = [
+  {
+    name: "Github Stars",
+    description: "Displays the star count of a repository.",
+    registry: "github-stats/github-stars.json",
+    component: GithubStarsExample,
+  },
+  {
+    name: "Github Forks",
+    description: "Displays the fork count of a repository.",
+    registry: "github-stats/github-forks.json",
+    component: GithubForksExample,
+  },
+  {
+    name: "Github Issues",
+    description: "Displays the count of open issues.",
+    registry: "github-stats/github-issues.json",
+    component: GithubIssuesExample,
+  },
+  {
+    name: "Github Pull Requests",
+    description: "Displays the count of open pull requests.",
+    registry: "github-stats/github-pull-requests.json",
+    component: GithubPRExample,
+  },
+];
+
+export default function Page() {
+  return (
+    <main className="max-w-6xl mx-auto flex flex-col px-4 py-8 flex-1 gap-8 md:gap-12">
+      {components.map((component) => (
+        <div
+          key={component.name}
+          id={component.name.toLowerCase().replace(/ /g, "-")}
+          className="flex flex-col gap-4"
+        >
+          <div className="flex gap-2 items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-sm line-clamp-1 font-medium">
+                {component.name}
+              </span>
+              <Separator
+                orientation="vertical"
+                className="!h-4 hidden lg:flex"
+              />
+              <span className="text-sm text-muted-foreground line-clamp-1 hidden lg:flex">
+                {component.description}
+              </span>
+            </div>
+            <div className="flex gap-2">
+              <CopyShadcn
+                text={`npx shadcn@latest add @ui/${component.registry.split("/")[1].split(".")[0]}`}
+              />
+              <CopyURL
+                url={`https://ui.raulcarini.dev/r/${component.registry.split("/")[1]}`}
+              />
+              <OpenCode
+                url={`https://github.com/R4ULtv/ui/blob/master/registry/${component.registry.split(".")[0]}.tsx`}
+              />
+              <OpenV0
+                url={`https://ui.raulcarini.dev/r/${component.registry.split("/")[1]}`}
+              />
+            </div>
+          </div>
+          <div className="flex items-center border rounded-lg justify-center min-h-[400px] p-4 md:p-10 relative bg-muted/30">
+            <component.component />
+          </div>
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -63,7 +63,6 @@ const components: Component[] = [
     name: "Theme Switch",
     count: 2,
     path: "/theme-switch",
-    new: true,
     images: {
       light: "/theme-switch-light.png",
       dark: "/theme-switch-dark.png",
@@ -73,7 +72,7 @@ const components: Component[] = [
     name: "Github Stats",
     count: 4,
     path: "/github-stats",
-    soon: true,
+    new: true,
     images: {
       light: "/github-stats-light.png",
       dark: "/github-stats-dark.png",

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -47,5 +47,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly",
       priority: 0.8,
     },
+    {
+      url: url("/github-stats"),
+      lastModified: new Date("2025-09-04"),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
   ];
 }

--- a/components/examples/github-stats.tsx
+++ b/components/examples/github-stats.tsx
@@ -1,0 +1,9 @@
+import { GithubForks } from "@/registry/github-stats/github-forks";
+import { GithubIssues } from "@/registry/github-stats/github-issues";
+import { GithubPR } from "@/registry/github-stats/github-pr";
+import { GithubStars } from "@/registry/github-stats/github-stars";
+
+export const GithubStarsExample = () => <GithubStars repo="r4ultv/ui" />;
+export const GithubForksExample = () => <GithubForks repo="r4ultv/ui" />;
+export const GithubIssuesExample = () => <GithubIssues repo="r4ultv/ui" />;
+export const GithubPRExample = () => <GithubPR repo="r4ultv/ui" />;

--- a/public/r/github-forks.json
+++ b/public/r/github-forks.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "github-forks",
+  "type": "registry:block",
+  "title": "GitHub Forks",
+  "description": "Displays the fork count of a repository.",
+  "dependencies": [
+    "lucide-react"
+  ],
+  "registryDependencies": [
+    "button",
+    "skeleton"
+  ],
+  "files": [
+    {
+      "path": "registry/github-stats/github-forks.tsx",
+      "content": "import * as React from \"react\";\n\nimport { Button } from \"@/components/ui/button\";\nimport { Skeleton } from \"@/components/ui/skeleton\";\nimport { GitForkIcon } from \"lucide-react\";\n\nexport function GithubForks({ repo }: { repo: string }) {\n  return (\n    <Button asChild size=\"sm\" variant=\"ghost\" className=\"h-8 shadow-none group\">\n      <a href=\"https://github.com/r4ultv/ui\" target=\"_blank\" rel=\"noreferrer\">\n        <GitForkIcon className=\"group-hover:scale-110 transition-transform duration-200 ease-out\" />\n        <React.Suspense fallback={<Skeleton className=\"h-4 w-9\" />}>\n          <ForksCount repo={repo} />\n        </React.Suspense>\n      </a>\n    </Button>\n  );\n}\n\nexport async function ForksCount({ repo }: { repo: string }) {\n  const data = await fetch(`https://api.github.com/repos/${repo}`, {\n    next: { revalidate: 86400 }, // Cache for 1 day (86400 seconds)\n  });\n  const json: { forks_count: number } = await data.json();\n\n  return (\n    <p className=\"text-xs text-muted-foreground/70 group-hover:text-muted-foreground transition-colors duration-200 ease-out\">\n      <span className=\"tabular-nums\">\n        {json.forks_count >= 1000\n          ? `${(json.forks_count / 1000).toFixed(1)}k`\n          : json.forks_count.toLocaleString()}\n      </span>{\" \"}\n      forks\n    </p>\n  );\n}\n",
+      "type": "registry:component"
+    }
+  ]
+}

--- a/public/r/github-issues.json
+++ b/public/r/github-issues.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "github-issues",
+  "type": "registry:block",
+  "title": "GitHub Issues",
+  "description": "Displays the count of open issues.",
+  "dependencies": [
+    "lucide-react"
+  ],
+  "registryDependencies": [
+    "button",
+    "skeleton"
+  ],
+  "files": [
+    {
+      "path": "registry/github-stats/github-issues.tsx",
+      "content": "import * as React from \"react\";\n\nimport { Button } from \"@/components/ui/button\";\nimport { Skeleton } from \"@/components/ui/skeleton\";\nimport { CircleDotIcon } from \"lucide-react\";\n\nexport function GithubIssues({ repo }: { repo: string }) {\n  return (\n    <Button asChild size=\"sm\" variant=\"ghost\" className=\"h-8 shadow-none group\">\n      <a href=\"https://github.com/r4ultv/ui\" target=\"_blank\" rel=\"noreferrer\">\n        <CircleDotIcon className=\"group-hover:scale-110 transition-transform duration-200 ease-out\" />\n        <React.Suspense fallback={<Skeleton className=\"h-4 w-10\" />}>\n          <IssuesCount repo={repo} />\n        </React.Suspense>\n      </a>\n    </Button>\n  );\n}\n\nexport async function IssuesCount({ repo }: { repo: string }) {\n  const data = await fetch(\n    `https://api.github.com/search/issues?q=repo:${repo}+is:issue+is:open`,\n    {\n      next: { revalidate: 86400 }, // Cache for 1 day (86400 seconds)\n    },\n  );\n  const json: { total_count: number } = await data.json();\n\n  return (\n    <p className=\"text-xs text-muted-foreground/70 group-hover:text-muted-foreground transition-colors duration-200 ease-out\">\n      <span className=\"tabular-nums\">\n        {json.total_count >= 1000\n          ? `${(json.total_count / 1000).toFixed(1)}k`\n          : json.total_count.toLocaleString()}\n      </span>{\" \"}\n      issues\n    </p>\n  );\n}\n",
+      "type": "registry:component"
+    }
+  ]
+}

--- a/public/r/github-pr.json
+++ b/public/r/github-pr.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "github-pr",
+  "type": "registry:block",
+  "title": "GitHub Pull Requests",
+  "description": "Displays the count of open pull requests.",
+  "dependencies": [
+    "lucide-react"
+  ],
+  "registryDependencies": [
+    "button",
+    "skeleton"
+  ],
+  "files": [
+    {
+      "path": "registry/github-stats/github-pr.tsx",
+      "content": "import * as React from \"react\";\n\nimport { Button } from \"@/components/ui/button\";\nimport { Skeleton } from \"@/components/ui/skeleton\";\nimport { GitPullRequestArrowIcon } from \"lucide-react\";\n\nexport function GithubPR({ repo }: { repo: string }) {\n  return (\n    <Button asChild size=\"sm\" variant=\"ghost\" className=\"h-8 shadow-none group\">\n      <a href=\"https://github.com/r4ultv/ui\" target=\"_blank\" rel=\"noreferrer\">\n        <GitPullRequestArrowIcon className=\"group-hover:scale-110 transition-transform duration-200 ease-out\" />\n        <React.Suspense fallback={<Skeleton className=\"h-4 w-20\" />}>\n          <PRCount repo={repo} />\n        </React.Suspense>\n      </a>\n    </Button>\n  );\n}\n\nexport async function PRCount({ repo }: { repo: string }) {\n  const data = await fetch(\n    `https://api.github.com/search/issues?q=repo:${repo}+is:pr+is:open`,\n    {\n      next: { revalidate: 86400 }, // Cache for 1 day (86400 seconds)\n    },\n  );\n  const json: { total_count: number } = await data.json();\n\n  return (\n    <p className=\"text-xs text-muted-foreground/70 group-hover:text-muted-foreground transition-colors duration-200 ease-out\">\n      <span className=\"tabular-nums\">\n        {json.total_count >= 1000\n          ? `${(json.total_count / 1000).toFixed(1)}k`\n          : json.total_count.toLocaleString()}\n      </span>{\" \"}\n      pull requests\n    </p>\n  );\n}\n",
+      "type": "registry:component"
+    }
+  ]
+}

--- a/public/r/github-stars.json
+++ b/public/r/github-stars.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "github-stars",
+  "type": "registry:block",
+  "title": "GitHub Stars",
+  "description": "Displays the star count of a repository.",
+  "dependencies": [
+    "lucide-react"
+  ],
+  "registryDependencies": [
+    "button",
+    "skeleton"
+  ],
+  "files": [
+    {
+      "path": "registry/github-stats/github-stars.tsx",
+      "content": "import * as React from \"react\";\n\nimport { Button } from \"@/components/ui/button\";\nimport { Skeleton } from \"@/components/ui/skeleton\";\nimport { StarIcon } from \"lucide-react\";\n\nexport function GithubStars({ repo }: { repo: string }) {\n  return (\n    <Button asChild size=\"sm\" variant=\"ghost\" className=\"h-8 shadow-none group\">\n      <a href=\"https://github.com/r4ultv/ui\" target=\"_blank\" rel=\"noreferrer\">\n        <StarIcon className=\"fill-transparent group-hover:fill-foreground group-hover:scale-110 transition-[fill,scale] duration-200 ease-out\" />\n        <React.Suspense fallback={<Skeleton className=\"h-4 w-9\" />}>\n          <StarsCount repo={repo} />\n        </React.Suspense>\n      </a>\n    </Button>\n  );\n}\n\nexport async function StarsCount({ repo }: { repo: string }) {\n  const data = await fetch(`https://api.github.com/repos/${repo}`, {\n    next: { revalidate: 86400 }, // Cache for 1 day (86400 seconds)\n  });\n  const json: { stargazers_count: number } = await data.json();\n\n  return (\n    <p className=\"text-xs text-muted-foreground/70 group-hover:text-muted-foreground transition-colors duration-200 ease-out\">\n      <span className=\"tabular-nums\">\n        {json.stargazers_count >= 1000\n          ? `${(json.stargazers_count / 1000).toFixed(1)}k`\n          : json.stargazers_count.toLocaleString()}\n      </span>{\" \"}\n      stars\n    </p>\n  );\n}\n",
+      "type": "registry:component"
+    }
+  ]
+}

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -355,6 +355,62 @@
       ],
       "registryDependencies": ["switch"],
       "dependencies": ["lucide-react", "next-themes"]
+    },
+    {
+      "name": "github-stars",
+      "type": "registry:block",
+      "title": "GitHub Stars",
+      "description": "Displays the star count of a repository.",
+      "files": [
+        {
+          "path": "registry/github-stats/github-stars.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": ["button", "skeleton"],
+      "dependencies": ["lucide-react"]
+    },
+    {
+      "name": "github-forks",
+      "type": "registry:block",
+      "title": "GitHub Forks",
+      "description": "Displays the fork count of a repository.",
+      "files": [
+        {
+          "path": "registry/github-stats/github-forks.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": ["button", "skeleton"],
+      "dependencies": ["lucide-react"]
+    },
+    {
+      "name": "github-issues",
+      "type": "registry:block",
+      "title": "GitHub Issues",
+      "description": "Displays the count of open issues.",
+      "files": [
+        {
+          "path": "registry/github-stats/github-issues.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": ["button", "skeleton"],
+      "dependencies": ["lucide-react"]
+    },
+    {
+      "name": "github-pr",
+      "type": "registry:block",
+      "title": "GitHub Pull Requests",
+      "description": "Displays the count of open pull requests.",
+      "files": [
+        {
+          "path": "registry/github-stats/github-pr.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": ["button", "skeleton"],
+      "dependencies": ["lucide-react"]
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -355,6 +355,62 @@
       ],
       "registryDependencies": ["switch"],
       "dependencies": ["lucide-react", "next-themes"]
+    },
+    {
+      "name": "github-stars",
+      "type": "registry:block",
+      "title": "GitHub Stars",
+      "description": "Displays the star count of a repository.",
+      "files": [
+        {
+          "path": "registry/github-stats/github-stars.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": ["button", "skeleton"],
+      "dependencies": ["lucide-react"]
+    },
+    {
+      "name": "github-forks",
+      "type": "registry:block",
+      "title": "GitHub Forks",
+      "description": "Displays the fork count of a repository.",
+      "files": [
+        {
+          "path": "registry/github-stats/github-forks.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": ["button", "skeleton"],
+      "dependencies": ["lucide-react"]
+    },
+    {
+      "name": "github-issues",
+      "type": "registry:block",
+      "title": "GitHub Issues",
+      "description": "Displays the count of open issues.",
+      "files": [
+        {
+          "path": "registry/github-stats/github-issues.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": ["button", "skeleton"],
+      "dependencies": ["lucide-react"]
+    },
+    {
+      "name": "github-pr",
+      "type": "registry:block",
+      "title": "GitHub Pull Requests",
+      "description": "Displays the count of open pull requests.",
+      "files": [
+        {
+          "path": "registry/github-stats/github-pr.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "registryDependencies": ["button", "skeleton"],
+      "dependencies": ["lucide-react"]
     }
   ]
 }

--- a/registry/github-stats/github-forks.tsx
+++ b/registry/github-stats/github-forks.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { GitForkIcon } from "lucide-react";
+
+export function GithubForks({ repo }: { repo: string }) {
+  return (
+    <Button asChild size="sm" variant="ghost" className="h-8 shadow-none group">
+      <a href="https://github.com/r4ultv/ui" target="_blank" rel="noreferrer">
+        <GitForkIcon className="group-hover:scale-110 transition-transform duration-200 ease-out" />
+        <React.Suspense fallback={<Skeleton className="h-4 w-9" />}>
+          <ForksCount repo={repo} />
+        </React.Suspense>
+      </a>
+    </Button>
+  );
+}
+
+export async function ForksCount({ repo }: { repo: string }) {
+  const data = await fetch(`https://api.github.com/repos/${repo}`, {
+    next: { revalidate: 86400 }, // Cache for 1 day (86400 seconds)
+  });
+  const json: { forks_count: number } = await data.json();
+
+  return (
+    <p className="text-xs text-muted-foreground/70 group-hover:text-muted-foreground transition-colors duration-200 ease-out">
+      <span className="tabular-nums">
+        {json.forks_count >= 1000
+          ? `${(json.forks_count / 1000).toFixed(1)}k`
+          : json.forks_count.toLocaleString()}
+      </span>{" "}
+      forks
+    </p>
+  );
+}

--- a/registry/github-stats/github-issues.tsx
+++ b/registry/github-stats/github-issues.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CircleDotIcon } from "lucide-react";
+
+export function GithubIssues({ repo }: { repo: string }) {
+  return (
+    <Button asChild size="sm" variant="ghost" className="h-8 shadow-none group">
+      <a href="https://github.com/r4ultv/ui" target="_blank" rel="noreferrer">
+        <CircleDotIcon className="group-hover:scale-110 transition-transform duration-200 ease-out" />
+        <React.Suspense fallback={<Skeleton className="h-4 w-10" />}>
+          <IssuesCount repo={repo} />
+        </React.Suspense>
+      </a>
+    </Button>
+  );
+}
+
+export async function IssuesCount({ repo }: { repo: string }) {
+  const data = await fetch(
+    `https://api.github.com/search/issues?q=repo:${repo}+is:issue+is:open`,
+    {
+      next: { revalidate: 86400 }, // Cache for 1 day (86400 seconds)
+    },
+  );
+  const json: { total_count: number } = await data.json();
+
+  return (
+    <p className="text-xs text-muted-foreground/70 group-hover:text-muted-foreground transition-colors duration-200 ease-out">
+      <span className="tabular-nums">
+        {json.total_count >= 1000
+          ? `${(json.total_count / 1000).toFixed(1)}k`
+          : json.total_count.toLocaleString()}
+      </span>{" "}
+      issues
+    </p>
+  );
+}

--- a/registry/github-stats/github-pr.tsx
+++ b/registry/github-stats/github-pr.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { GitPullRequestArrowIcon } from "lucide-react";
+
+export function GithubPR({ repo }: { repo: string }) {
+  return (
+    <Button asChild size="sm" variant="ghost" className="h-8 shadow-none group">
+      <a href="https://github.com/r4ultv/ui" target="_blank" rel="noreferrer">
+        <GitPullRequestArrowIcon className="group-hover:scale-110 transition-transform duration-200 ease-out" />
+        <React.Suspense fallback={<Skeleton className="h-4 w-20" />}>
+          <PRCount repo={repo} />
+        </React.Suspense>
+      </a>
+    </Button>
+  );
+}
+
+export async function PRCount({ repo }: { repo: string }) {
+  const data = await fetch(
+    `https://api.github.com/search/issues?q=repo:${repo}+is:pr+is:open`,
+    {
+      next: { revalidate: 86400 }, // Cache for 1 day (86400 seconds)
+    },
+  );
+  const json: { total_count: number } = await data.json();
+
+  return (
+    <p className="text-xs text-muted-foreground/70 group-hover:text-muted-foreground transition-colors duration-200 ease-out">
+      <span className="tabular-nums">
+        {json.total_count >= 1000
+          ? `${(json.total_count / 1000).toFixed(1)}k`
+          : json.total_count.toLocaleString()}
+      </span>{" "}
+      pull requests
+    </p>
+  );
+}

--- a/registry/github-stats/github-stars.tsx
+++ b/registry/github-stats/github-stars.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { StarIcon } from "lucide-react";
+
+export function GithubStars({ repo }: { repo: string }) {
+  return (
+    <Button asChild size="sm" variant="ghost" className="h-8 shadow-none group">
+      <a href="https://github.com/r4ultv/ui" target="_blank" rel="noreferrer">
+        <StarIcon className="fill-transparent group-hover:fill-foreground group-hover:scale-110 transition-[fill,scale] duration-200 ease-out" />
+        <React.Suspense fallback={<Skeleton className="h-4 w-9" />}>
+          <StarsCount repo={repo} />
+        </React.Suspense>
+      </a>
+    </Button>
+  );
+}
+
+export async function StarsCount({ repo }: { repo: string }) {
+  const data = await fetch(`https://api.github.com/repos/${repo}`, {
+    next: { revalidate: 86400 }, // Cache for 1 day (86400 seconds)
+  });
+  const json: { stargazers_count: number } = await data.json();
+
+  return (
+    <p className="text-xs text-muted-foreground/70 group-hover:text-muted-foreground transition-colors duration-200 ease-out">
+      <span className="tabular-nums">
+        {json.stargazers_count >= 1000
+          ? `${(json.stargazers_count / 1000).toFixed(1)}k`
+          : json.stargazers_count.toLocaleString()}
+      </span>{" "}
+      stars
+    </p>
+  );
+}


### PR DESCRIPTION
This PR introduces a new collection of GitHub statistics components that display real-time repository data including stars, forks, issues, and pull requests. These components seamlessly integrate with the existing shadcn UI registry and follow the established patterns of the project.

## ✨ New Components

### 📊 GitHub Stats Collection

- **`github-stars.tsx`** - Displays repository star count with interactive hover effects
- **`github-forks.tsx`** - Shows repository fork count with smooth animations  
- **`github-issues.tsx`** - Presents open issues count with real-time data
- **`github-pr.tsx`** - Displays open pull requests count with live updates

## 🎯 Features

- **Real-time Data**: Fetches live GitHub API data with 24-hour caching for optimal performance
- **Interactive UI**: Smooth hover animations with scale transforms and color transitions
- **Smart Formatting**: Automatically formats large numbers (1k+ format) with proper localization
- **Loading States**: Integrated skeleton loading components for better UX
- **Responsive Design**: Consistent styling that matches the existing component library
- **Accessibility**: Proper ARIA attributes and semantic HTML structure